### PR TITLE
BUGFIX: Initialize usageStrategies as empty array

### DIFF
--- a/Classes/TYPO3/Media/Domain/Service/AssetService.php
+++ b/Classes/TYPO3/Media/Domain/Service/AssetService.php
@@ -71,7 +71,7 @@ class AssetService
     /**
      * @var array
      */
-    protected $usageStrategies;
+    protected $usageStrategies = [];
 
     /**
      * @Flow\Inject


### PR DESCRIPTION
Currently, the Asset models of the Media package cannot be used without having an AssetUsageStrategy implemented. If no such strategy is implemented (e.g. by using Media without Neos and no need for usage information), using an Asset model will lead to a fatal error because the AssetService is trying to loop $usageStrategies which is not an empty array, but null. Therefore, $usageStrategies must be initialized as an empty array.