### PR TITLE
BUGFIX: Make `getVariant()` parameters optional

### DIFF
--- a/Classes/Domain/Model/Image.php
+++ b/Classes/Domain/Model/Image.php
@@ -138,13 +138,13 @@ class Image extends Asset implements ImageInterface, VariantSupportInterface
     /**
      * Returns the variant identified by $presetIdentifier and $presetVariantName (if existing)
      *
-     * @param string $presetIdentifier
-     * @param string $presetVariantName
+     * @param string|null $presetIdentifier
+     * @param string|null $presetVariantName
      * @return AssetVariantInterface|ImageVariant
      */
-    public function getVariant(string $presetIdentifier, string $presetVariantName): ?AssetVariantInterface
+    public function getVariant(string|null $presetIdentifier = null, string|null $presetVariantName = null): ?AssetVariantInterface
     {
-        if ($this->variants->isEmpty()) {
+        if ($this->variants->isEmpty() || $presetIdentifier === null || $presetVariantName === null) {
             return null;
         }
 


### PR DESCRIPTION
When I add images to the `ImageRepository` with an import job I get the error: `Too few arguments to function ::getVariant(), 0 passed, 2 expected`. The default value `null` would solve the problem.